### PR TITLE
add Date.now() wrapper

### DIFF
--- a/src/Data.Date.purs
+++ b/src/Data.Date.purs
@@ -32,6 +32,7 @@ module Data.Date
   , millisecond
   , millisecondUTC
   , timezoneOffset
+  , epochMilliseconds
   , toEpochMilliseconds
   , fromEpochMilliseconds
   , fromString
@@ -349,6 +350,14 @@ millisecondUTC = liftDate $ jsDateMethod "getUTCMilliseconds"
 
 timezoneOffset :: Date -> Minutes
 timezoneOffset = liftDate $ jsDateMethod "getTimezoneOffset"
+
+foreign import epochMilliseconds """
+  function epochMilliseconds() {
+    return function () {
+      return Date.now();
+    }
+  }
+  """ :: foreall e. Eff e Number
 
 toEpochMilliseconds :: Date -> Milliseconds
 toEpochMilliseconds = liftDate $ jsDateMethod "getTime"

--- a/src/Data.Date.purs
+++ b/src/Data.Date.purs
@@ -357,7 +357,7 @@ foreign import epochMilliseconds """
       return Date.now();
     }
   }
-  """ :: forall e. Eff e Milliseconds
+  """ :: forall e. Eff (now :: Now | e) Milliseconds
 
 toEpochMilliseconds :: Date -> Milliseconds
 toEpochMilliseconds = liftDate $ jsDateMethod "getTime"

--- a/src/Data.Date.purs
+++ b/src/Data.Date.purs
@@ -357,7 +357,7 @@ foreign import epochMilliseconds """
       return Date.now();
     }
   }
-  """ :: forall e. Eff e Number
+  """ :: forall e. Eff e Milliseconds
 
 toEpochMilliseconds :: Date -> Milliseconds
 toEpochMilliseconds = liftDate $ jsDateMethod "getTime"

--- a/src/Data.Date.purs
+++ b/src/Data.Date.purs
@@ -357,7 +357,7 @@ foreign import epochMilliseconds """
       return Date.now();
     }
   }
-  """ :: foreall e. Eff e Number
+  """ :: forall e. Eff e Number
 
 toEpochMilliseconds :: Date -> Milliseconds
 toEpochMilliseconds = liftDate $ jsDateMethod "getTime"

--- a/src/Data.Date.purs
+++ b/src/Data.Date.purs
@@ -353,9 +353,7 @@ timezoneOffset = liftDate $ jsDateMethod "getTimezoneOffset"
 
 foreign import epochMilliseconds """
   function epochMilliseconds() {
-    return function () {
-      return Date.now();
-    }
+    return Date.now();
   }
   """ :: forall e. Eff (now :: Now | e) Milliseconds
 


### PR DESCRIPTION
Just in case this is the right domain, I noticed the `Date.now()` function isn't included. Of course it can be obtained via `now >>= toEpochMilliseconds`, but it seems a shame to instantiate a new `Date` and add a new effect to `Eff` when this shortcut exists.