### PR TITLE
Fixed a bug where an exception was thrown using the UTC module.

### DIFF
--- a/src/Data/Date/UTC.purs
+++ b/src/Data/Date/UTC.purs
@@ -74,6 +74,6 @@ foreign import dateMethod
 foreign import jsDateFromValues
   """
   function jsDateFromValues(y, mo, d, h, mi, s, ms) {
-    return Date.UTC(y, mo, d, h, mi, s, ms);
+    return new Date(Date.UTC(y, mo, d, h, mi, s, ms));
   }
   """ :: Fn7 Year Number DayOfMonth HourOfDay MinuteOfHour SecondOfMinute MillisecondOfSecond JSDate


### PR DESCRIPTION
Date.UTC doesn't return a valid JavaScript Date object, but rather just the time in milliseconds since epoch. This meant that the dateTime method was broken. This fixes that by modifying jsDateFromValues to pass the value from Date.UTC to the Date constructor.